### PR TITLE
rm cx

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -53,7 +53,7 @@ RBNF.@parser QASMLang begin
     uop = (inst | ugate | csemantic_gate)
     inst::Instruction := [name = id, ['(', [cargs = explist].?, ')'].?, qargs = bitlist, ';']
     ugate::UGate := [:U, '(', z1 = exp, ',', y = exp, ',', z2 = exp, ')', qarg = bit, ';']
-    csemantic_gate::CXGate := [:CXGate, ctrl = bit, ',', qarg = bit, ';']
+    csemantic_gate::CXGate := [:CX, ctrl = bit, ',', qarg = bit, ';']
 
     idlist = @direct_recur begin
         init = [id]

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -53,7 +53,7 @@ RBNF.@parser QASMLang begin
     uop = (inst | ugate | csemantic_gate)
     inst::Instruction := [name = id, ['(', [cargs = explist].?, ')'].?, qargs = bitlist, ';']
     ugate::UGate := [:U, '(', z1 = exp, ',', y = exp, ',', z2 = exp, ')', qarg = bit, ';']
-    csemantic_gate::CXGate := [:CX | :cx, ctrl = bit, ',', qarg = bit, ';']
+    csemantic_gate::CXGate := [:CXGate, ctrl = bit, ',', qarg = bit, ';']
 
     idlist = @direct_recur begin
         init = [id]


### PR DESCRIPTION
the `cx` (lowercase) gate is provided by `qelib1.inc` as an instruction, it is not part of the intrinsic.

cc: @contra-bit @madhavkrishnan